### PR TITLE
public label struct

### DIFF
--- a/label.go
+++ b/label.go
@@ -7,9 +7,9 @@ import (
 	"github.com/rs/zerolog"
 )
 
-type label struct {
-	key   string
-	value string
+type LabelSource struct {
+	Key   string
+	Value string
 }
 
 type labels struct {
@@ -23,20 +23,20 @@ func newLabels() *labels {
 
 // Label adds an optional label to the payload in the format of `key: value`.
 // Key of label must start with `labels.`
-func Label(key, value string) *label {
-	return &label{key: "labels." + key, value: value}
+func Label(key, value string) *LabelSource {
+	return &LabelSource{Key: "labels." + key, Value: value}
 }
 
 // Labels takes label structs, filters the ones that have their key start with the
 // string `labels.` and their value type set to string type. It then wraps those
 // key/value pairs in a top-level `labels` namespace.
-func (e *Event) Labels(labels ...*label) *zerolog.Event {
+func (e *Event) Labels(labels ...*LabelSource) *zerolog.Event {
 	lbls := newLabels()
 
 	lbls.mutex.Lock()
 	for i := range labels {
 		if isLabelEvent(labels[i]) {
-			lbls.store[strings.Replace(labels[i].key, "labels.", "", 1)] = labels[i].value
+			lbls.store[strings.Replace(labels[i].Key, "labels.", "", 1)] = labels[i].Value
 		}
 	}
 	lbls.mutex.Unlock()
@@ -44,6 +44,6 @@ func (e *Event) Labels(labels ...*label) *zerolog.Event {
 	return e.Event.Dict("logging.googleapis.com/labels", zerolog.Dict().Fields(lbls.store))
 }
 
-func isLabelEvent(label *label) bool {
-	return strings.HasPrefix(label.key, "labels.")
+func isLabelEvent(label *LabelSource) bool {
+	return strings.HasPrefix(label.Key, "labels.")
 }

--- a/label.go
+++ b/label.go
@@ -27,7 +27,7 @@ func Label(key, value string) *LabelSource {
 	return &LabelSource{Key: "labels." + key, Value: value}
 }
 
-// Labels takes label structs, filters the ones that have their key start with the
+// Labels takes LabelSource structs, filters the ones that have their key start with the
 // string `labels.` and their value type set to string type. It then wraps those
 // key/value pairs in a top-level `labels` namespace.
 func (e *Event) Labels(labels ...*LabelSource) *zerolog.Event {

--- a/label_test.go
+++ b/label_test.go
@@ -12,7 +12,7 @@ func TestLabel(t *testing.T) {
 	t.Parallel()
 
 	l := Label("key", "value")
-	assert.Equal(t, &label{key: "labels.key", value: "value"}, l)
+	assert.Equal(t, &LabelSource{Key: "labels.key", Value: "value"}, l)
 }
 
 func TestLabels(t *testing.T) {


### PR DESCRIPTION
The type of the `label` struct is private. Therefore, it is not possible to add a label conditionally. 

When this request is merged, the following processing will be possible.

```go
labels := make([]zerodriver.LabelSouce, 0, 0)

// Conditional branch pattern
if useSpecialLabel() {
    labels = append(lebels, zerodriver.Label("x", "x"))
}

// Loop pattern
for k, v := range DefaultLabels{
    labels = append(lebels,  zerodriver.Label(k, v))
}

// pass []LabelSource to Label method.
logger.Info().Labels(...labels).Msg("labeled log")
```

## discuss

Because the name `Label` was duplicated, I renamed the label struct to `labelSource`. Do you have any other good names ?