### PR TITLE
Add support for error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,38 @@ logger.Info().OperationStart("foo", "bar").Msg("started")
 logger.Debug().OperationContinue("foo", "bar").Msg("processing")
 logger.Info().OperationEnd("foo", "bar").Msg("done")
 ```
+
+#### Using Error Reporting
+To report errors using StackDriver's Error Reporting tool, a log line needs to follow a separate log format described in the [Error Reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages) documentation.
+
+A concrete example of error reporting format log is as follows:
+```go
+logger := zerodriver.NewProductionLogger(
+    zerodriver.WithServiceName("my service"),
+    zerodriver.WithReportAllErrors(),
+)
+```
+
+
+#### Reporting errors manually
+If you do not want every error to be reported, you can attach ErrorReport() to log call manually:
+```go
+logger.Error("An error to be reported!").ErrorReport(runtime.Caller(0))
+```
+※ When you use `zerodriver.WithReportAllErrors()`, the manually added error report will be duplicated.
+
+※ Please keep in mind that ErrorReport needs a `ServiceContext` attached to the log entry. If you did not configure this using `WithServiceContext`, error reports will get attached using service name as `unknown`. To prevent this from happening, either configure your core or attach service context before (or when) using the logger:
+```go
+logger.Error().
+    ServiceContext().
+    ErrorReport(runtime.Caller(0).
+    Msg("An error message to be reported!")
+```
+Or permanently attach it to your logger
+```go
+logger := zerodriver.NewProductionLogger(zerodriver.WithServiceName("my service"))
+logger.Error().
+    ErrorReport(runtime.Caller(0).
+    Msg("An error message to be reported!")
+```
+

--- a/caller.go
+++ b/caller.go
@@ -1,0 +1,20 @@
+package zerodriver
+
+import (
+	"runtime"
+	"testing"
+)
+
+var caller = realCaller
+
+func realCaller(skip int) (pc uintptr, file string, line int, ok bool) {
+	return runtime.Caller(skip)
+}
+
+func mockCaller(t *testing.T, frame runtime.Frame, ok bool) {
+	t.Helper()
+
+	caller = func(skip int) (uintptr, string, int, bool) {
+		return frame.PC, frame.File, frame.Line, ok
+	}
+}

--- a/label.go
+++ b/label.go
@@ -30,7 +30,7 @@ func Label(key, value string) *LabelSource {
 // Labels takes LabelSource structs, filters the ones that have their key start with the
 // string `labels.` and their value type set to string type. It then wraps those
 // key/value pairs in a top-level `labels` namespace.
-func (e *Event) Labels(labels ...*LabelSource) *zerolog.Event {
+func (e *Event) Labels(labels ...*LabelSource) *Event {
 	lbls := newLabels()
 
 	lbls.mutex.Lock()
@@ -41,7 +41,8 @@ func (e *Event) Labels(labels ...*LabelSource) *zerolog.Event {
 	}
 	lbls.mutex.Unlock()
 
-	return e.Event.Dict("logging.googleapis.com/labels", zerolog.Dict().Fields(lbls.store))
+	e.Event.Dict("logging.googleapis.com/labels", zerolog.Dict().Fields(lbls.store))
+	return e
 }
 
 func isLabelEvent(label *LabelSource) bool {

--- a/logger.go
+++ b/logger.go
@@ -7,12 +7,21 @@ import (
 	"github.com/rs/zerolog"
 )
 
+type config struct {
+	serviceName     string
+	reportAllErrors bool
+}
+
 type Logger struct {
 	*zerolog.Logger
+	config *config
 }
 
 type Event struct {
 	*zerolog.Event
+
+	config *config
+	level  zerolog.Level
 }
 
 // See: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
@@ -27,7 +36,7 @@ var logLevelSeverity = map[zerolog.Level]string{
 
 // NewProductionLogger returns a configured logger for production.
 // It outputs info level and above logs with sampling.
-func NewProductionLogger() *Logger {
+func NewProductionLogger(opts ...Option) *Logger {
 	logLevel := zerolog.InfoLevel
 	zerolog.SetGlobalLevel(logLevel)
 
@@ -42,12 +51,13 @@ func NewProductionLogger() *Logger {
 	sampler := &zerolog.BasicSampler{N: 1}
 
 	logger := zerolog.New(os.Stderr).Sample(sampler).With().Timestamp().Logger()
-	return &Logger{&logger}
+	logger.With().Caller().Caller()
+	return &Logger{Logger: &logger, config: newConfig(opts...)}
 }
 
 // NewDevelopmentLogger returns a configured logger for development.
 // It outputs debug level and above logs, and sampling is disabled.
-func NewDevelopmentLogger() *Logger {
+func NewDevelopmentLogger(opts ...Option) *Logger {
 	logLevel := zerolog.DebugLevel
 	zerolog.SetGlobalLevel(logLevel)
 
@@ -59,59 +69,59 @@ func NewDevelopmentLogger() *Logger {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
 	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
-	return &Logger{&logger}
+	return &Logger{Logger: &logger, config: newConfig(opts...)}
 }
 
 // To use method chain we need followings
 
 func (l *Logger) Trace() *Event {
 	e := l.Logger.Trace()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.TraceLevel}
 }
 
 func (l *Logger) Debug() *Event {
 	e := l.Logger.Debug()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.DebugLevel}
 }
 
 func (l *Logger) Info() *Event {
 	e := l.Logger.Info()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.InfoLevel}
 }
 
 func (l *Logger) Warn() *Event {
 	e := l.Logger.Warn()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.WarnLevel}
 }
 
 func (l *Logger) Error() *Event {
 	e := l.Logger.Error()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.ErrorLevel}
 }
 
 func (l *Logger) Err(err error) *Event {
 	e := l.Logger.Error().Err(err)
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.ErrorLevel}
 }
 
 func (l *Logger) Fatal() *Event {
 	e := l.Logger.Fatal()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.FatalLevel}
 }
 
 func (l *Logger) Panic() *Event {
 	e := l.Logger.Panic()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.PanicLevel}
 }
 
 func (l *Logger) WithLevel(level zerolog.Level) *Event {
 	e := l.Logger.WithLevel(level)
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: level}
 }
 
 func (l *Logger) Log() *Event {
 	e := l.Logger.Log()
-	return &Event{e}
+	return &Event{Event: e, config: l.config, level: zerolog.NoLevel}
 }
 
 func (l *Logger) Print(v ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -33,35 +33,35 @@ func TestLoggers(t *testing.T) {
 	}{
 		"trace": {
 			res:  log.Trace(),
-			want: &Event{log.Logger.Trace()},
+			want: &Event{Event: log.Logger.Trace(), config: &config{}, level: zerolog.TraceLevel},
 		},
 		"debug": {
 			res:  log.Debug(),
-			want: &Event{log.Logger.Debug()},
+			want: &Event{Event: log.Logger.Debug(), config: &config{}, level: zerolog.DebugLevel},
 		},
 		"info": {
 			res:  log.Info(),
-			want: &Event{log.Logger.Info()},
+			want: &Event{Event: log.Logger.Info(), config: &config{}, level: zerolog.InfoLevel},
 		},
 		"warn": {
 			res:  log.Warn(),
-			want: &Event{log.Logger.Warn()},
+			want: &Event{Event: log.Logger.Warn(), config: &config{}, level: zerolog.WarnLevel},
 		},
 		"error": {
 			res:  log.Error(),
-			want: &Event{log.Logger.Error()},
+			want: &Event{Event: log.Logger.Error(), config: &config{}, level: zerolog.ErrorLevel},
 		},
 		"err": {
 			res:  log.Err(errors.New("some error")),
-			want: &Event{log.Logger.Err(errors.New("some error"))},
+			want: &Event{Event: log.Logger.Err(errors.New("some error")), config: &config{}, level: zerolog.ErrorLevel},
 		},
 		"with level": {
 			res:  log.WithLevel(zerolog.InfoLevel),
-			want: &Event{log.Logger.WithLevel(zerolog.InfoLevel)},
+			want: &Event{Event: log.Logger.Info(), config: &config{}, level: zerolog.InfoLevel},
 		},
 		"log": {
 			res:  log.Log(),
-			want: &Event{log.Logger.Log()},
+			want: &Event{Event: log.Logger.Log(), config: &config{}, level: zerolog.NoLevel},
 		},
 	}
 	for name, tt := range tests {

--- a/msg.go
+++ b/msg.go
@@ -1,5 +1,18 @@
 package zerodriver
 
+import "github.com/rs/zerolog"
+
 func (e *Event) Msg(msg string) {
+	if e.config.serviceName != "" {
+		e.ServiceContext(e.config.serviceName)
+	}
+	if e.config.reportAllErrors && e.level >= zerolog.ErrorLevel {
+		if e.config.serviceName == "" {
+			// A service name was not set but error report needs it
+			// So attempt to add a generic service name
+			e.ServiceContext(unknownServiceName)
+		}
+		e.ErrorReport(caller(zerolog.CallerSkipFrameCount))
+	}
 	e.Event.Msg(msg)
 }

--- a/msg.go
+++ b/msg.go
@@ -1,0 +1,5 @@
+package zerodriver
+
+func (e *Event) Msg(msg string) {
+	e.Event.Msg(msg)
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -1,0 +1,28 @@
+package zerodriver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_EventMsg(t *testing.T) {
+	t.Parallel()
+
+	// replace writer
+	log := NewProductionLogger()
+	out := &bytes.Buffer{}
+	logger := zerolog.New(out).With().Logger()
+	log.Logger = &logger
+
+	log.Info().Msg("test")
+	actual := out.String()
+	out.Reset()
+
+	logger.Info().Msg("test")
+	expected := out.String()
+
+	assert.Equal(t, expected, actual)
+}

--- a/operation.go
+++ b/operation.go
@@ -1,9 +1,5 @@
 package zerodriver
 
-import (
-	"github.com/rs/zerolog"
-)
-
 // operation is the complete payload that can be interpreted by Cloud Logging as
 // an operation.
 // see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntryOperation
@@ -28,7 +24,7 @@ type operation struct {
 //
 // Additional information about a potentially long-running operation with which
 // a log entry is associated.
-func (e *Event) Operation(id, producer string, first, last bool) *zerolog.Event {
+func (e *Event) Operation(id, producer string, first, last bool) *Event {
 	op := &operation{
 		ID:       id,
 		Producer: producer,
@@ -36,23 +32,24 @@ func (e *Event) Operation(id, producer string, first, last bool) *zerolog.Event 
 		Last:     last,
 	}
 
-	return e.Event.Interface("logging.googleapis.com/operation", op)
+	e.Event.Interface("logging.googleapis.com/operation", op)
+	return e
 }
 
 // OperationStart is a function for logging `Operation`. It should be called
 // for the first operation log.
-func (e *Event) OperationStart(id, producer string) *zerolog.Event {
+func (e *Event) OperationStart(id, producer string) *Event {
 	return e.Operation(id, producer, true, false)
 }
 
 // OperationContinue is a function for logging `Operation`. It should be called
 // for any non-start/end operation log.
-func (e *Event) OperationContinue(id, producer string) *zerolog.Event {
+func (e *Event) OperationContinue(id, producer string) *Event {
 	return e.Operation(id, producer, false, false)
 }
 
 // OperationEnd is a function for logging `Operation`. It should be called
 // for the last operation log.
-func (e *Event) OperationEnd(id, producer string) *zerolog.Event {
+func (e *Event) OperationEnd(id, producer string) *Event {
 	return e.Operation(id, producer, false, true)
 }

--- a/option.go
+++ b/option.go
@@ -1,0 +1,42 @@
+package zerodriver
+
+func newConfig(opts ...Option) *config {
+	var cfg config
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return &cfg
+}
+
+// Option is an option to change logger configuration.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc struct {
+	f func(*config)
+}
+
+func (o *optionFunc) apply(opts *config) {
+	o.f(opts)
+}
+
+func newOptionFunc(f func(cfg *config)) *optionFunc {
+	return &optionFunc{
+		f: f,
+	}
+}
+
+// WithServiceName enable adding serviceContext field with given service name.
+func WithServiceName(serviceName string) Option {
+	return newOptionFunc(func(cfg *config) {
+		cfg.serviceName = serviceName
+	})
+}
+
+// WithReportAllErrors enable adding fields used for error reporting when log level is error or above.
+func WithReportAllErrors() Option {
+	return newOptionFunc(func(cfg *config) {
+		cfg.reportAllErrors = true
+	})
+}

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,114 @@
+package zerodriver
+
+import (
+	"bytes"
+	"encoding/json"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithServiceName(t *testing.T) {
+	t.Parallel()
+
+	// replace writer
+	log := NewProductionLogger(WithServiceName("test-gcp-project"))
+	out := &bytes.Buffer{}
+	logger := zerolog.New(out).With().Logger()
+	log.Logger = &logger
+
+	log.Info().Msg("test")
+	actual := out.String()
+	out.Reset()
+
+	log.Info().Dict("serviceContext", zerolog.Dict().
+		Str("service", "test-gcp-project")).
+		Msg("test")
+	expected := out.String()
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestWithEventErrorReport(t *testing.T) {
+	frame := runtime.Frame{
+		PC:   0,
+		File: "/a/b/c/dummy.go",
+		Line: 10,
+	}
+	mockCaller(t, frame, true)
+
+	tests := []struct {
+		name   string
+		logger *Logger
+		level  zerolog.Level
+		want   map[string]interface{}
+	}{
+		{
+			name: "Add fields when log level is error",
+			logger: NewProductionLogger(
+				WithServiceName("test-project"),
+				WithReportAllErrors(),
+			),
+			level: zerolog.ErrorLevel,
+			want: map[string]interface{}{
+				"serviceContext": map[string]string{
+					"service": "test-project",
+				},
+				"context": map[string]interface{}{
+					"reportLocation": map[string]interface{}{
+						"filePath":     frame.File,
+						"lineNumber":   strconv.Itoa(frame.Line),
+						"functionName": "",
+					},
+				},
+			},
+		},
+		{
+			name:   "Add fields with unknown service name when service name is not set",
+			logger: NewProductionLogger(WithReportAllErrors()),
+			level:  zerolog.ErrorLevel,
+			want: map[string]interface{}{
+				"serviceContext": map[string]string{
+					"service": "unknown",
+				},
+				"context": map[string]interface{}{
+					"reportLocation": map[string]interface{}{
+						"filePath":     frame.File,
+						"lineNumber":   strconv.Itoa(frame.Line),
+						"functionName": "",
+					},
+				},
+			},
+		},
+		{
+			name:   "Don't add fields when log level is below error",
+			logger: NewProductionLogger(WithReportAllErrors()),
+			level:  zerolog.InfoLevel,
+			want:   map[string]interface{}{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			log := tt.logger
+			logger := zerolog.New(out).With().Logger()
+			log.Logger = &logger
+
+			log.WithLevel(tt.level).Msg("test")
+			actual := make(map[string]interface{})
+			err := json.Unmarshal([]byte(out.String()), &actual)
+			assert.NoError(t, err)
+			out.Reset()
+
+			log.WithLevel(tt.level).Fields(tt.want).Msg("test")
+			expected := make(map[string]interface{})
+			err = json.Unmarshal([]byte(out.String()), &expected)
+			assert.NoError(t, err)
+
+			assert.Equal(t, expected, actual)
+		})
+	}
+}

--- a/report.go
+++ b/report.go
@@ -1,0 +1,49 @@
+package zerodriver
+
+import (
+	"runtime"
+	"strconv"
+)
+
+const contextKey = "context"
+
+type reportLocation struct {
+	File     string `json:"filePath"`
+	Line     string `json:"lineNumber"`
+	Function string `json:"functionName"`
+}
+
+// reportContext is the context information attached to a log for reporting errors
+type reportContext struct {
+	ReportLocation reportLocation `json:"reportLocation"`
+}
+
+func newReportContext(pc uintptr, file string, line int) *reportContext {
+	var function string
+	if fn := runtime.FuncForPC(pc); fn != nil {
+		function = fn.Name()
+	}
+
+	context := &reportContext{
+		ReportLocation: reportLocation{
+			File:     file,
+			Line:     strconv.Itoa(line),
+			Function: function,
+		},
+	}
+
+	return context
+}
+
+// ErrorReport adds the correct Stackdriver "context" field for getting the log line
+// reported as error.
+//
+// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+func (e *Event) ErrorReport(pc uintptr, file string, line int, ok bool) *Event {
+	if !ok {
+		return e
+	}
+
+	e.Interface(contextKey, newReportContext(pc, file, line))
+	return e
+}

--- a/report_test.go
+++ b/report_test.go
@@ -1,0 +1,53 @@
+package zerodriver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Add error reporting context fields when caller is ok", func(t *testing.T) {
+		// replace writer
+		log := NewProductionLogger()
+		out := &bytes.Buffer{}
+		logger := zerolog.New(out).With().Logger()
+		log.Logger = &logger
+
+		log.Info().ErrorReport(0, "a/b/c/dummy.go", 10, true).Msg("test")
+		actual := out.String()
+		out.Reset()
+
+		log.Info().Dict("context", zerolog.Dict().Dict(
+			"reportLocation", zerolog.Dict().
+				Str("filePath", "a/b/c/dummy.go").
+				Str("lineNumber", "10").
+				Str("functionName", ""),
+		)).
+			Msg("test")
+		expected := out.String()
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Add error reporting context fields when failed to get caller", func(t *testing.T) {
+		// replace writer
+		log := NewProductionLogger()
+		out := &bytes.Buffer{}
+		logger := zerolog.New(out).With().Logger()
+		log.Logger = &logger
+
+		log.Info().ErrorReport(0, "", 0, false).Msg("test")
+		actual := out.String()
+		out.Reset()
+
+		log.Info().Msg("test")
+		expected := out.String()
+
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/service.go
+++ b/service.go
@@ -1,0 +1,16 @@
+package zerodriver
+
+const (
+	unknownServiceName = "unknown"
+	serviceContextKey  = "serviceContext"
+)
+
+// ServiceContext adds the correct service information adding the log line
+// It is a required field if an error needs to be reported.
+//
+// see: https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext
+// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+func (e *Event) ServiceContext(serviceName string) *Event {
+	e.Interface(serviceContextKey, map[string]string{"service": serviceName})
+	return e
+}

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,30 @@
+package zerodriver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceContext(t *testing.T) {
+	t.Parallel()
+
+	// replace writer
+	log := NewProductionLogger()
+	out := &bytes.Buffer{}
+	logger := zerolog.New(out).With().Logger()
+	log.Logger = &logger
+
+	log.Info().ServiceContext("test-gcp-project").Msg("test")
+	actual := out.String()
+	out.Reset()
+
+	log.Info().Dict("serviceContext", zerolog.Dict().
+		Str("service", "test-gcp-project")).
+		Msg("test")
+	expected := out.String()
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Resolve #11

This PR adds support for [error reporting](https://cloud.google.com/error-reporting/docs/formatting-error-messages) as an option. Most of the implementation are in reference to [zapdriver's implementation](https://github.com/blendle/zapdriver/blob/master/report.go)

https://github.com/hirosassa/zerodriver/pull/17 or similar PR to wrap all zerolog `Event`'s methods must be merged first to make this PR work.