### PR TITLE
Add Output function

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package zerodriver
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -125,4 +126,12 @@ func (l *Logger) Printf(format string, v ...interface{}) {
 func (l Logger) Write(p []byte) (n int, err error) {
 	n, err = l.Logger.Write(p)
 	return n, err
+}
+
+func (l Logger) Output(w io.Writer) Logger {
+	logger := l.Logger.Output(w)
+	l2 := Logger{
+		Logger: &logger,
+	}
+	return l2
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,6 +2,7 @@ package zerodriver
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"testing"
@@ -26,7 +27,7 @@ func TestLoggers(t *testing.T) {
 
 	log := NewProductionLogger()
 
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		res     *Event
 		want    *Event
 		wantErr error
@@ -163,4 +164,19 @@ func TestWrite(t *testing.T) {
 	n, err := log.Write([]byte("abc"))
 	assert.Equal(t, 3, n)
 	assert.NoError(t, err)
+}
+
+func TestOutput(t *testing.T) {
+	t.Parallel()
+
+	out := &bytes.Buffer{}
+	log := NewProductionLogger().Output(out)
+
+	_, err := log.Write([]byte("abc"))
+	assert.NoError(t, err)
+
+	var output map[string]interface{}
+	err = json.NewDecoder(out).Decode(&output)
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", output["message"], "Logger should write to io.Writer")
 }


### PR DESCRIPTION
zerolog.Logger has Output function. And, zerodriver.Logger can also call Output function, because zerolog.Logger is embedded struct for zerodriver.Logger. But, the return value is not zerodriver.Logger, but zerolog.Logger. This PR fix the return value to be zerodriver.Logger.